### PR TITLE
Check for nested Addon folder

### DIFF
--- a/resources/lib/update_addon.py
+++ b/resources/lib/update_addon.py
@@ -66,6 +66,8 @@ def _extract_addon(zip_location, repo):
             except Exception as e:
                 tools.log("Could not extract {}: {}".format(f, e))
     install_path = os.path.join(_addons, repo["plugin_id"])
+    if repo["plugin_id"] in os.listdir(os.path.join(_temp, base_directory)):
+        base_directory += repo["plugin_id"]
     tools.copytree(os.path.join(_temp, base_directory), install_path, ignore=True)
     tools.remove_folder(os.path.join(_temp, base_directory))
     tools.remove_file(zip_location)


### PR DESCRIPTION
Check if addon is nested inside project and change install base accordingly.

Basically would check if project is improperly set up for this tool. Also helps solve my issue of multiple addons in one repo.